### PR TITLE
feat: tokenized strategy access into library

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ solc = "0.8.18"
 evm_version = "paris"
 optimize = true
 optimizer_runs = 200
+no_match_test = "testFail"
 
 remappings = [
     'forge-std/=lib/forge-std/src/',

--- a/src/BaseStrategy.sol
+++ b/src/BaseStrategy.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.8.18;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-// TokenizedStrategy interface used for internal view delegateCalls.
 import {ITokenizedStrategy} from "./interfaces/ITokenizedStrategy.sol";
+import {TokenizedStrategyLib as TokenizedStrategy} from "./libraries/TokenizedStrategyLib.sol";
 
 /**
  * @title YearnV3 Base Strategy
@@ -32,8 +32,7 @@ import {ITokenizedStrategy} from "./interfaces/ITokenizedStrategy.sol";
  *  contains all needed global variables in a manual storage slot. This
  *  means strategists can feel free to implement their own custom storage
  *  variables as they need with no concern of collisions. All global variables
- *  can be viewed within the Strategy by a simple call using the
- *  `TokenizedStrategy` variable. IE: TokenizedStrategy.globalVariable();.
+ *  can be viewed within the Strategy using `TokenizedStrategy`.
  */
 abstract contract BaseStrategy {
     /*//////////////////////////////////////////////////////////////
@@ -112,44 +111,32 @@ abstract contract BaseStrategy {
     ERC20 internal immutable asset;
 
     /**
-     * @dev This variable is set to address(this) during initialization of each strategy.
-     *
-     * This can be used to retrieve storage data within the strategy
-     * contract as if it were a linked library.
-     *
-     *       i.e. uint256 totalAssets = TokenizedStrategy.totalAssets()
-     *
-     * Using address(this) will mean any calls using this variable will lead
-     * to a call to itself. Which will hit the fallback function and
-     * delegateCall that to the actual TokenizedStrategy.
-     */
-    ITokenizedStrategy internal immutable TokenizedStrategy;
-
-    /**
      * @notice Used to initialize the strategy on deployment.
      *
-     * This will set the `TokenizedStrategy` variable for easy
-     * internal view calls to the implementation. As well as
-     * initializing the default storage variables based on the
-     * parameters and using the deployer for the permissioned roles.
+     * This will initialize the default storage variables based on the
+     * parameters and use the deployer for the permissioned roles.
      *
      * @param _asset Address of the underlying asset.
      * @param _name Name the strategy will use.
      */
     constructor(address _asset, string memory _name) {
-        (asset, TokenizedStrategy) = _initialize(_asset, _name);
+        asset = ERC20(_asset);
+        _initialize(_asset, _name, msg.sender, msg.sender, msg.sender);
     }
 
     /// @dev Internal function to initialize the strategy.
     function _initialize(
         address _asset,
-        string memory _name
-    ) internal virtual returns (ERC20, ITokenizedStrategy) {
+        string memory _name,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin
+    ) internal virtual {
         // Initialize the strategy's storage variables.
         _delegateCall(
             abi.encodeCall(
                 ITokenizedStrategy.initialize,
-                (_asset, _name, msg.sender, msg.sender, msg.sender)
+                (_asset, _name, _management, _keeper, _emergencyAdmin)
             )
         );
 
@@ -163,8 +150,6 @@ abstract contract BaseStrategy {
                 tokenizedStrategyAddress
             )
         }
-
-        return (ERC20(_asset), ITokenizedStrategy(address(this)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -324,11 +309,11 @@ abstract contract BaseStrategy {
      * be overridden by strategists.
      *
      * This function will be called before any withdraw or redeem to enforce
-     * any limits desired by the strategist. This can be used for illiquid
-     * or sandwichable strategies. It should never be lower than `totalIdle`.
+     * any limits desired by the strategist or integrated protocol. This can
+     * be used for illiquid or sandwichable strategies.
      *
      *   EX:
-     *       return TokenIzedStrategy.totalIdle();
+     *       return asset.balanceOf(address(this));
      *
      * This does not need to take into account the `_owner`'s share balance
      * or conversion rates from shares to assets.

--- a/src/BaseStrategy.sol
+++ b/src/BaseStrategy.sol
@@ -129,14 +129,14 @@ abstract contract BaseStrategy {
         address _asset,
         string memory _name,
         address _management,
-        address _keeper,
-        address _emergencyAdmin
+        address _performanceFeeRecipient,
+        address _keeper
     ) internal virtual {
         // Initialize the strategy's storage variables.
         _delegateCall(
             abi.encodeCall(
                 ITokenizedStrategy.initialize,
-                (_asset, _name, _management, _keeper, _emergencyAdmin)
+                (_asset, _name, _management, _performanceFeeRecipient, _keeper)
             )
         );
 

--- a/src/libraries/TokenizedStrategyLib.sol
+++ b/src/libraries/TokenizedStrategyLib.sol
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.18;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+import {ITokenizedStrategy} from "../interfaces/ITokenizedStrategy.sol";
+
+library TokenizedStrategyLib {
+    bytes32 internal constant BASE_STRATEGY_STORAGE =
+        bytes32(uint256(keccak256("yearn.base.strategy.storage")) - 1);
+
+    // prettier-ignore
+    struct StrategyData {
+        ERC20 asset;
+        uint8 decimals;
+        string name;
+        uint256 totalSupply;
+        mapping(address => uint256) nonces;
+        mapping(address => uint256) balances;
+        mapping(address => mapping(address => uint256)) allowances;
+        uint256 lastTotalAssets;
+        uint256 profitUnlockingRate;
+        uint96 fullProfitUnlockDate;
+        address keeper;
+        uint32 profitMaxUnlockTime;
+        uint16 performanceFee;
+        address performanceFeeRecipient;
+        uint96 lastReport;
+        address management;
+        address pendingManagement;
+        address emergencyAdmin;
+        uint8 entered;
+        bool shutdown;
+        uint96 lastAccrual;
+    }
+
+    function strategyStorage() internal pure returns (StrategyData storage S) {
+        bytes32 slot = BASE_STRATEGY_STORAGE;
+        assembly {
+            S.slot := slot
+        }
+    }
+
+    function asset() internal view returns (address) {
+        return address(strategyStorage().asset);
+    }
+
+    function name() internal view returns (string memory) {
+        return strategyStorage().name;
+    }
+
+    function symbol() internal view returns (string memory) {
+        return ITokenizedStrategy(address(this)).symbol();
+    }
+
+    function decimals() internal view returns (uint8) {
+        return strategyStorage().decimals;
+    }
+
+    function apiVersion() internal view returns (string memory) {
+        return ITokenizedStrategy(address(this)).apiVersion();
+    }
+
+    function MAX_FEE() internal view returns (uint16) {
+        return ITokenizedStrategy(address(this)).MAX_FEE();
+    }
+
+    function FACTORY() internal view returns (address) {
+        return ITokenizedStrategy(address(this)).FACTORY();
+    }
+
+    function management() internal view returns (address) {
+        return strategyStorage().management;
+    }
+
+    function pendingManagement() internal view returns (address) {
+        return strategyStorage().pendingManagement;
+    }
+
+    function keeper() internal view returns (address) {
+        return strategyStorage().keeper;
+    }
+
+    function emergencyAdmin() internal view returns (address) {
+        return strategyStorage().emergencyAdmin;
+    }
+
+    function performanceFee() internal view returns (uint16) {
+        return strategyStorage().performanceFee;
+    }
+
+    function performanceFeeRecipient() internal view returns (address) {
+        return strategyStorage().performanceFeeRecipient;
+    }
+
+    function profitMaxUnlockTime() internal view returns (uint256) {
+        uint256 _profitMaxUnlockTime = strategyStorage().profitMaxUnlockTime;
+        if (_profitMaxUnlockTime == type(uint32).max) {
+            return type(uint256).max;
+        }
+
+        return _profitMaxUnlockTime;
+    }
+
+    function lastReport() internal view returns (uint256) {
+        return uint256(strategyStorage().lastReport);
+    }
+
+    function lastAccrual() internal view returns (uint256) {
+        return uint256(strategyStorage().lastAccrual);
+    }
+
+    function lastTotalAssets() internal view returns (uint256) {
+        return strategyStorage().lastTotalAssets;
+    }
+
+    function fullProfitUnlockDate() internal view returns (uint256) {
+        return uint256(strategyStorage().fullProfitUnlockDate);
+    }
+
+    function profitUnlockingRate() internal view returns (uint256) {
+        return strategyStorage().profitUnlockingRate;
+    }
+
+    function isShutdown() internal view returns (bool) {
+        return strategyStorage().shutdown;
+    }
+
+    function totalAssets() internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).totalAssets();
+    }
+
+    function totalSupply() internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).totalSupply();
+    }
+
+    function balanceOf(address _account) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).balanceOf(_account);
+    }
+
+    function allowance(
+        address _owner,
+        address _spender
+    ) internal view returns (uint256) {
+        return strategyStorage().allowances[_owner][_spender];
+    }
+
+    function nonces(address _owner) internal view returns (uint256) {
+        return strategyStorage().nonces[_owner];
+    }
+
+    function DOMAIN_SEPARATOR() internal view returns (bytes32) {
+        return ITokenizedStrategy(address(this)).DOMAIN_SEPARATOR();
+    }
+
+    function unlockedShares() internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).unlockedShares();
+    }
+
+    function requireManagement(address _sender) internal view {
+        require(_sender == strategyStorage().management, "!management");
+    }
+
+    function requireKeeperOrManagement(address _sender) internal view {
+        StrategyData storage S = strategyStorage();
+        require(_sender == S.keeper || _sender == S.management, "!keeper");
+    }
+
+    function requireEmergencyAuthorized(address _sender) internal view {
+        StrategyData storage S = strategyStorage();
+        require(
+            _sender == S.emergencyAdmin || _sender == S.management,
+            "!emergency authorized"
+        );
+    }
+
+    function pricePerShare() internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).pricePerShare();
+    }
+
+    function convertToShares(uint256 _assets) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).convertToShares(_assets);
+    }
+
+    function convertToAssets(uint256 _shares) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).convertToAssets(_shares);
+    }
+
+    function previewDeposit(uint256 _assets) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).previewDeposit(_assets);
+    }
+
+    function previewMint(uint256 _shares) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).previewMint(_shares);
+    }
+
+    function previewWithdraw(uint256 _assets) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).previewWithdraw(_assets);
+    }
+
+    function previewRedeem(uint256 _shares) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).previewRedeem(_shares);
+    }
+
+    function maxDeposit(address _receiver) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).maxDeposit(_receiver);
+    }
+
+    function maxMint(address _receiver) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).maxMint(_receiver);
+    }
+
+    function maxWithdraw(address _owner) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).maxWithdraw(_owner);
+    }
+
+    function maxWithdraw(
+        address _owner,
+        uint256 _maxLoss
+    ) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).maxWithdraw(_owner, _maxLoss);
+    }
+
+    function maxRedeem(address _owner) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).maxRedeem(_owner);
+    }
+
+    function maxRedeem(
+        address _owner,
+        uint256 _maxLoss
+    ) internal view returns (uint256) {
+        return ITokenizedStrategy(address(this)).maxRedeem(_owner, _maxLoss);
+    }
+}

--- a/src/test/AccessControl.t.sol
+++ b/src/test/AccessControl.t.sol
@@ -4,6 +4,52 @@ pragma solidity >=0.8.18;
 import "forge-std/console.sol";
 import {Setup} from "./utils/Setup.sol";
 
+import {BaseStrategy, ERC20} from "../BaseStrategy.sol";
+import {ITokenizedStrategy} from "../interfaces/ITokenizedStrategy.sol";
+
+// Minimal strategy that overrides `_initialize` to demonstrate that role
+// addresses passed to `super._initialize` land in the correct storage slots.
+// The override uses named arguments, so it only compiles when the parent's
+// parameter names align with `ITokenizedStrategy.initialize`.
+contract CustomInitMockStrategy is BaseStrategy {
+    address internal constant CUSTOM_MANAGEMENT =
+        0x1111111111111111111111111111111111111111;
+    address internal constant CUSTOM_FEE_RECIPIENT =
+        0x2222222222222222222222222222222222222222;
+    address internal constant CUSTOM_KEEPER =
+        0x3333333333333333333333333333333333333333;
+
+    constructor(address _asset) BaseStrategy(_asset, "Custom Init") {}
+
+    function _initialize(
+        address _asset,
+        string memory _name,
+        address,
+        address,
+        address
+    ) internal override {
+        super._initialize({
+            _asset: _asset,
+            _name: _name,
+            _management: CUSTOM_MANAGEMENT,
+            _performanceFeeRecipient: CUSTOM_FEE_RECIPIENT,
+            _keeper: CUSTOM_KEEPER
+        });
+    }
+
+    function _deployFunds(uint256) internal override {}
+
+    function _freeFunds(uint256) internal override {}
+
+    function _totalAssets() internal view override returns (uint256) {
+        return asset.balanceOf(address(this));
+    }
+
+    function _harvestAndReport() internal override returns (uint256) {
+        return _totalAssets();
+    }
+}
+
 contract AccessControlTest is Setup {
     function setUp() public override {
         super.setUp();
@@ -369,6 +415,29 @@ contract AccessControlTest is Setup {
 
         vm.prank(keeper);
         strategy.tend();
+    }
+
+    function test_initializeOverride_routesAddressesToCorrectSlots() public {
+        CustomInitMockStrategy custom = new CustomInitMockStrategy(
+            address(asset)
+        );
+        ITokenizedStrategy s = ITokenizedStrategy(address(custom));
+
+        assertEq(
+            s.management(),
+            0x1111111111111111111111111111111111111111,
+            "!management"
+        );
+        assertEq(
+            s.performanceFeeRecipient(),
+            0x2222222222222222222222222222222222222222,
+            "!performanceFeeRecipient"
+        );
+        assertEq(
+            s.keeper(),
+            0x3333333333333333333333333333333333333333,
+            "!keeper"
+        );
     }
 
     function test_setName(address _address) public {

--- a/src/test/ERC4626Std.t.sol
+++ b/src/test/ERC4626Std.t.sol
@@ -34,4 +34,47 @@ contract ERC4626StdTest is ERC4626Test, Setup {
         if (assets == type(uint256).max) assets -= 1;
         super.test_deposit(init, assets, allowance);
     }
+
+    // The pinned ERC4626 test suite still uses legacy `testFail_*` names for
+    // these cases. Newer Forge versions reject those, so we filter them out in
+    // foundry.toml and keep the same coverage here with explicit expectRevert.
+    function test_erc4626WithdrawWithoutAllowanceReverts(
+        Init memory init,
+        uint256 assets
+    ) public {
+        setUpVault(init);
+        address caller = init.user[0];
+        address receiver = init.user[1];
+        address owner = init.user[2];
+        assets = bound(assets, 0, _max_withdraw(owner));
+
+        vm.assume(caller != owner);
+        vm.assume(assets > 0);
+
+        _approve(_vault_, owner, caller, 0);
+
+        vm.expectRevert();
+        vm.prank(caller);
+        strategy.withdraw(assets, receiver, owner);
+    }
+
+    function test_erc4626RedeemWithoutAllowanceReverts(
+        Init memory init,
+        uint256 shares
+    ) public {
+        setUpVault(init);
+        address caller = init.user[0];
+        address receiver = init.user[1];
+        address owner = init.user[2];
+        shares = bound(shares, 0, _max_redeem(owner));
+
+        vm.assume(caller != owner);
+        vm.assume(shares > 0);
+
+        _approve(_vault_, owner, caller, 0);
+
+        vm.expectRevert();
+        vm.prank(caller);
+        strategy.redeem(shares, receiver, owner);
+    }
 }

--- a/src/test/TokenizedStrategyLibViews.t.sol
+++ b/src/test/TokenizedStrategyLibViews.t.sol
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.18;
+
+import {Setup} from "./utils/Setup.sol";
+import {MockStrategy} from "./mocks/MockStrategy.sol";
+
+contract TokenizedStrategyLibViewsTest is Setup {
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256(
+            "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+        );
+
+    MockStrategy internal libraryStrategy;
+
+    function setUp() public override {
+        super.setUp();
+        libraryStrategy = MockStrategy(address(strategy));
+    }
+
+    function test_tokenizedStrategyLibraryViewsMatchDirectCalls() public {
+        uint256 ownerSk = 0xA11CE;
+        address owner = vm.addr(ownerSk);
+        address spender = address(0xBEEF);
+        address pendingManagement = address(0xCAFE);
+        address newKeeper = address(0xD00D);
+        address newEmergencyAdmin = address(0xEAA);
+        address newPerformanceFeeRecipient = address(0xFEE);
+        uint256 amount = 100_000 * wad;
+
+        _assertAllViewsMatch(owner, spender, amount / 10, amount / 20, 77);
+
+        setFees(0, 1_250);
+        mintAndDepositIntoStrategy(strategy, owner, amount);
+
+        vm.prank(owner);
+        strategy.approve(spender, amount / 3);
+
+        _permit(owner, spender, amount / 7, 1 days, ownerSk);
+
+        vm.prank(management);
+        strategy.setPendingManagement(pendingManagement);
+
+        vm.prank(management);
+        strategy.setPerformanceFeeRecipient(newPerformanceFeeRecipient);
+
+        vm.prank(management);
+        strategy.setProfitMaxUnlockTime(14 days);
+
+        skip(1);
+        createAndCheckProfit(strategy, amount / 5, 0, amount / 40);
+
+        vm.prank(management);
+        strategy.setKeeper(newKeeper);
+
+        vm.prank(management);
+        strategy.setEmergencyAdmin(newEmergencyAdmin);
+
+        skip(3 days);
+        _assertAllViewsMatch(owner, spender, amount / 11, amount / 13, 123);
+        _assertAccountViewsMatch(address(strategy), spender);
+        _assertAccountViewsMatch(newPerformanceFeeRecipient, spender);
+
+        vm.prank(newEmergencyAdmin);
+        strategy.shutdownStrategy();
+
+        _assertAllViewsMatch(owner, spender, amount / 17, amount / 19, MAX_BPS);
+        _assertAuthHelpersMatch(newKeeper, newEmergencyAdmin);
+    }
+
+    function _assertAllViewsMatch(
+        address owner,
+        address spender,
+        uint256 assets,
+        uint256 shares,
+        uint256 maxLoss
+    ) internal {
+        assertEq(libraryStrategy.libraryAsset(), strategy.asset(), "asset");
+        assertEq(
+            keccak256(bytes(libraryStrategy.libraryName())),
+            keccak256(bytes(strategy.name())),
+            "name"
+        );
+        assertEq(
+            keccak256(bytes(libraryStrategy.librarySymbol())),
+            keccak256(bytes(strategy.symbol())),
+            "symbol"
+        );
+        assertEq(
+            libraryStrategy.libraryDecimals(),
+            strategy.decimals(),
+            "decimals"
+        );
+        assertEq(
+            keccak256(bytes(libraryStrategy.libraryApiVersion())),
+            keccak256(bytes(strategy.apiVersion())),
+            "apiVersion"
+        );
+        assertEq(
+            libraryStrategy.libraryMAX_FEE(),
+            strategy.MAX_FEE(),
+            "MAX_FEE"
+        );
+        assertEq(
+            libraryStrategy.libraryFACTORY(),
+            strategy.FACTORY(),
+            "FACTORY"
+        );
+        assertEq(
+            libraryStrategy.libraryManagement(),
+            strategy.management(),
+            "management"
+        );
+        assertEq(
+            libraryStrategy.libraryPendingManagement(),
+            strategy.pendingManagement(),
+            "pendingManagement"
+        );
+        assertEq(libraryStrategy.libraryKeeper(), strategy.keeper(), "keeper");
+        assertEq(
+            libraryStrategy.libraryEmergencyAdmin(),
+            strategy.emergencyAdmin(),
+            "emergencyAdmin"
+        );
+        assertEq(
+            libraryStrategy.libraryPerformanceFee(),
+            strategy.performanceFee(),
+            "performanceFee"
+        );
+        assertEq(
+            libraryStrategy.libraryPerformanceFeeRecipient(),
+            strategy.performanceFeeRecipient(),
+            "performanceFeeRecipient"
+        );
+        assertEq(
+            libraryStrategy.libraryProfitMaxUnlockTime(),
+            strategy.profitMaxUnlockTime(),
+            "profitMaxUnlockTime"
+        );
+        assertEq(
+            libraryStrategy.libraryLastReport(),
+            strategy.lastReport(),
+            "lastReport"
+        );
+        assertEq(
+            libraryStrategy.libraryLastAccrual(),
+            strategy.lastAccrual(),
+            "lastAccrual"
+        );
+        assertEq(
+            libraryStrategy.libraryLastTotalAssets(),
+            strategy.lastTotalAssets(),
+            "lastTotalAssets"
+        );
+        assertEq(
+            libraryStrategy.libraryFullProfitUnlockDate(),
+            strategy.fullProfitUnlockDate(),
+            "fullProfitUnlockDate"
+        );
+        assertEq(
+            libraryStrategy.libraryProfitUnlockingRate(),
+            strategy.profitUnlockingRate(),
+            "profitUnlockingRate"
+        );
+        assertEq(
+            libraryStrategy.libraryIsShutdown(),
+            strategy.isShutdown(),
+            "isShutdown"
+        );
+        assertEq(
+            libraryStrategy.libraryTotalAssets(),
+            strategy.totalAssets(),
+            "totalAssets"
+        );
+        assertEq(
+            libraryStrategy.libraryTotalSupply(),
+            strategy.totalSupply(),
+            "totalSupply"
+        );
+        assertEq(
+            libraryStrategy.libraryDOMAIN_SEPARATOR(),
+            strategy.DOMAIN_SEPARATOR(),
+            "DOMAIN_SEPARATOR"
+        );
+        assertEq(
+            libraryStrategy.libraryUnlockedShares(),
+            strategy.unlockedShares(),
+            "unlockedShares"
+        );
+        assertEq(
+            libraryStrategy.libraryPricePerShare(),
+            strategy.pricePerShare(),
+            "pricePerShare"
+        );
+        assertEq(
+            libraryStrategy.libraryConvertToShares(assets),
+            strategy.convertToShares(assets),
+            "convertToShares"
+        );
+        assertEq(
+            libraryStrategy.libraryConvertToAssets(shares),
+            strategy.convertToAssets(shares),
+            "convertToAssets"
+        );
+        assertEq(
+            libraryStrategy.libraryPreviewDeposit(assets),
+            strategy.previewDeposit(assets),
+            "previewDeposit"
+        );
+        assertEq(
+            libraryStrategy.libraryPreviewMint(shares),
+            strategy.previewMint(shares),
+            "previewMint"
+        );
+        assertEq(
+            libraryStrategy.libraryPreviewWithdraw(assets),
+            strategy.previewWithdraw(assets),
+            "previewWithdraw"
+        );
+        assertEq(
+            libraryStrategy.libraryPreviewRedeem(shares),
+            strategy.previewRedeem(shares),
+            "previewRedeem"
+        );
+        assertEq(
+            libraryStrategy.libraryMaxDeposit(owner),
+            strategy.maxDeposit(owner),
+            "maxDeposit"
+        );
+        assertEq(
+            libraryStrategy.libraryMaxMint(owner),
+            strategy.maxMint(owner),
+            "maxMint"
+        );
+        assertEq(
+            libraryStrategy.libraryMaxWithdraw(owner),
+            strategy.maxWithdraw(owner),
+            "maxWithdraw"
+        );
+        assertEq(
+            libraryStrategy.libraryMaxWithdraw(owner, maxLoss),
+            strategy.maxWithdraw(owner, maxLoss),
+            "maxWithdraw maxLoss"
+        );
+        assertEq(
+            libraryStrategy.libraryMaxRedeem(owner),
+            strategy.maxRedeem(owner),
+            "maxRedeem"
+        );
+        assertEq(
+            libraryStrategy.libraryMaxRedeem(owner, maxLoss),
+            strategy.maxRedeem(owner, maxLoss),
+            "maxRedeem maxLoss"
+        );
+
+        _assertAccountViewsMatch(owner, spender);
+    }
+
+    function _assertAccountViewsMatch(address owner, address spender) internal {
+        assertEq(
+            libraryStrategy.libraryBalanceOf(owner),
+            strategy.balanceOf(owner),
+            "balanceOf"
+        );
+        assertEq(
+            libraryStrategy.libraryAllowance(owner, spender),
+            strategy.allowance(owner, spender),
+            "allowance"
+        );
+        assertEq(
+            libraryStrategy.libraryNonces(owner),
+            strategy.nonces(owner),
+            "nonces"
+        );
+    }
+
+    function _assertAuthHelpersMatch(
+        address currentKeeper,
+        address currentEmergencyAdmin
+    ) internal {
+        strategy.requireManagement(management);
+        libraryStrategy.libraryRequireManagement(management);
+
+        strategy.requireKeeperOrManagement(management);
+        strategy.requireKeeperOrManagement(currentKeeper);
+        libraryStrategy.libraryRequireKeeperOrManagement(management);
+        libraryStrategy.libraryRequireKeeperOrManagement(currentKeeper);
+
+        strategy.requireEmergencyAuthorized(management);
+        strategy.requireEmergencyAuthorized(currentEmergencyAdmin);
+        libraryStrategy.libraryRequireEmergencyAuthorized(management);
+        libraryStrategy.libraryRequireEmergencyAuthorized(
+            currentEmergencyAdmin
+        );
+
+        vm.expectRevert("!management");
+        strategy.requireManagement(address(0xBAD));
+        vm.expectRevert("!management");
+        libraryStrategy.libraryRequireManagement(address(0xBAD));
+
+        vm.expectRevert("!keeper");
+        strategy.requireKeeperOrManagement(address(0xBAD));
+        vm.expectRevert("!keeper");
+        libraryStrategy.libraryRequireKeeperOrManagement(address(0xBAD));
+
+        vm.expectRevert("!emergency authorized");
+        strategy.requireEmergencyAuthorized(address(0xBAD));
+        vm.expectRevert("!emergency authorized");
+        libraryStrategy.libraryRequireEmergencyAuthorized(address(0xBAD));
+    }
+
+    function _permit(
+        address owner,
+        address spender,
+        uint256 amount,
+        uint256 deadline,
+        uint256 ownerSk
+    ) internal {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                PERMIT_TYPEHASH,
+                owner,
+                spender,
+                amount,
+                strategy.nonces(owner),
+                deadline
+            )
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                strategy.DOMAIN_SEPARATOR(),
+                structHash
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerSk, digest);
+
+        strategy.permit(owner, spender, amount, deadline, v, r, s);
+    }
+}

--- a/src/test/mocks/MockFaultyStrategy.sol
+++ b/src/test/mocks/MockFaultyStrategy.sol
@@ -2,8 +2,7 @@
 pragma solidity >=0.8.18;
 
 import {MockYieldSource} from "./MockYieldSource.sol";
-import {BaseStrategy, ERC20} from "../../BaseStrategy.sol";
-import {TokenizedStrategyLib as TokenizedStrategy} from "../../libraries/TokenizedStrategyLib.sol";
+import {BaseStrategy, ERC20, TokenizedStrategy} from "../../BaseStrategy.sol";
 
 interface IPappa {
     function callBack(

--- a/src/test/mocks/MockFaultyStrategy.sol
+++ b/src/test/mocks/MockFaultyStrategy.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.18;
 
 import {MockYieldSource} from "./MockYieldSource.sol";
 import {BaseStrategy, ERC20} from "../../BaseStrategy.sol";
+import {TokenizedStrategyLib as TokenizedStrategy} from "../../libraries/TokenizedStrategyLib.sol";
 
 interface IPappa {
     function callBack(

--- a/src/test/mocks/MockStrategy.sol
+++ b/src/test/mocks/MockStrategy.sol
@@ -77,4 +77,203 @@ contract MockStrategy is BaseStrategy {
     function onlyLetEmergencyAdminsIn() public onlyEmergencyAuthorized {
         emergentizated = true;
     }
+
+    function libraryAsset() external view returns (address) {
+        return TokenizedStrategy.asset();
+    }
+
+    function libraryName() external view returns (string memory) {
+        return TokenizedStrategy.name();
+    }
+
+    function librarySymbol() external view returns (string memory) {
+        return TokenizedStrategy.symbol();
+    }
+
+    function libraryDecimals() external view returns (uint8) {
+        return TokenizedStrategy.decimals();
+    }
+
+    function libraryApiVersion() external view returns (string memory) {
+        return TokenizedStrategy.apiVersion();
+    }
+
+    function libraryMAX_FEE() external view returns (uint16) {
+        return TokenizedStrategy.MAX_FEE();
+    }
+
+    function libraryFACTORY() external view returns (address) {
+        return TokenizedStrategy.FACTORY();
+    }
+
+    function libraryManagement() external view returns (address) {
+        return TokenizedStrategy.management();
+    }
+
+    function libraryPendingManagement() external view returns (address) {
+        return TokenizedStrategy.pendingManagement();
+    }
+
+    function libraryKeeper() external view returns (address) {
+        return TokenizedStrategy.keeper();
+    }
+
+    function libraryEmergencyAdmin() external view returns (address) {
+        return TokenizedStrategy.emergencyAdmin();
+    }
+
+    function libraryPerformanceFee() external view returns (uint16) {
+        return TokenizedStrategy.performanceFee();
+    }
+
+    function libraryPerformanceFeeRecipient() external view returns (address) {
+        return TokenizedStrategy.performanceFeeRecipient();
+    }
+
+    function libraryProfitMaxUnlockTime() external view returns (uint256) {
+        return TokenizedStrategy.profitMaxUnlockTime();
+    }
+
+    function libraryLastReport() external view returns (uint256) {
+        return TokenizedStrategy.lastReport();
+    }
+
+    function libraryLastAccrual() external view returns (uint256) {
+        return TokenizedStrategy.lastAccrual();
+    }
+
+    function libraryLastTotalAssets() external view returns (uint256) {
+        return TokenizedStrategy.lastTotalAssets();
+    }
+
+    function libraryFullProfitUnlockDate() external view returns (uint256) {
+        return TokenizedStrategy.fullProfitUnlockDate();
+    }
+
+    function libraryProfitUnlockingRate() external view returns (uint256) {
+        return TokenizedStrategy.profitUnlockingRate();
+    }
+
+    function libraryIsShutdown() external view returns (bool) {
+        return TokenizedStrategy.isShutdown();
+    }
+
+    function libraryTotalAssets() external view returns (uint256) {
+        return TokenizedStrategy.totalAssets();
+    }
+
+    function libraryTotalSupply() external view returns (uint256) {
+        return TokenizedStrategy.totalSupply();
+    }
+
+    function libraryBalanceOf(
+        address _account
+    ) external view returns (uint256) {
+        return TokenizedStrategy.balanceOf(_account);
+    }
+
+    function libraryAllowance(
+        address _owner,
+        address _spender
+    ) external view returns (uint256) {
+        return TokenizedStrategy.allowance(_owner, _spender);
+    }
+
+    function libraryNonces(address _owner) external view returns (uint256) {
+        return TokenizedStrategy.nonces(_owner);
+    }
+
+    function libraryDOMAIN_SEPARATOR() external view returns (bytes32) {
+        return TokenizedStrategy.DOMAIN_SEPARATOR();
+    }
+
+    function libraryUnlockedShares() external view returns (uint256) {
+        return TokenizedStrategy.unlockedShares();
+    }
+
+    function libraryPricePerShare() external view returns (uint256) {
+        return TokenizedStrategy.pricePerShare();
+    }
+
+    function libraryConvertToShares(
+        uint256 _assets
+    ) external view returns (uint256) {
+        return TokenizedStrategy.convertToShares(_assets);
+    }
+
+    function libraryConvertToAssets(
+        uint256 _shares
+    ) external view returns (uint256) {
+        return TokenizedStrategy.convertToAssets(_shares);
+    }
+
+    function libraryPreviewDeposit(
+        uint256 _assets
+    ) external view returns (uint256) {
+        return TokenizedStrategy.previewDeposit(_assets);
+    }
+
+    function libraryPreviewMint(
+        uint256 _shares
+    ) external view returns (uint256) {
+        return TokenizedStrategy.previewMint(_shares);
+    }
+
+    function libraryPreviewWithdraw(
+        uint256 _assets
+    ) external view returns (uint256) {
+        return TokenizedStrategy.previewWithdraw(_assets);
+    }
+
+    function libraryPreviewRedeem(
+        uint256 _shares
+    ) external view returns (uint256) {
+        return TokenizedStrategy.previewRedeem(_shares);
+    }
+
+    function libraryMaxDeposit(
+        address _receiver
+    ) external view returns (uint256) {
+        return TokenizedStrategy.maxDeposit(_receiver);
+    }
+
+    function libraryMaxMint(address _receiver) external view returns (uint256) {
+        return TokenizedStrategy.maxMint(_receiver);
+    }
+
+    function libraryMaxWithdraw(
+        address _owner
+    ) external view returns (uint256) {
+        return TokenizedStrategy.maxWithdraw(_owner);
+    }
+
+    function libraryMaxWithdraw(
+        address _owner,
+        uint256 _maxLoss
+    ) external view returns (uint256) {
+        return TokenizedStrategy.maxWithdraw(_owner, _maxLoss);
+    }
+
+    function libraryMaxRedeem(address _owner) external view returns (uint256) {
+        return TokenizedStrategy.maxRedeem(_owner);
+    }
+
+    function libraryMaxRedeem(
+        address _owner,
+        uint256 _maxLoss
+    ) external view returns (uint256) {
+        return TokenizedStrategy.maxRedeem(_owner, _maxLoss);
+    }
+
+    function libraryRequireManagement(address _sender) external view {
+        TokenizedStrategy.requireManagement(_sender);
+    }
+
+    function libraryRequireKeeperOrManagement(address _sender) external view {
+        TokenizedStrategy.requireKeeperOrManagement(_sender);
+    }
+
+    function libraryRequireEmergencyAuthorized(address _sender) external view {
+        TokenizedStrategy.requireEmergencyAuthorized(_sender);
+    }
 }

--- a/src/test/mocks/MockStrategy.sol
+++ b/src/test/mocks/MockStrategy.sol
@@ -2,8 +2,7 @@
 pragma solidity >=0.8.18;
 
 import {MockYieldSource} from "./MockYieldSource.sol";
-import {BaseStrategy, ERC20} from "../../BaseStrategy.sol";
-import {TokenizedStrategyLib as TokenizedStrategy} from "../../libraries/TokenizedStrategyLib.sol";
+import {BaseStrategy, ERC20, TokenizedStrategy} from "../../BaseStrategy.sol";
 
 contract MockStrategy is BaseStrategy {
     address public yieldSource;

--- a/src/test/mocks/MockStrategy.sol
+++ b/src/test/mocks/MockStrategy.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.18;
 
 import {MockYieldSource} from "./MockYieldSource.sol";
 import {BaseStrategy, ERC20} from "../../BaseStrategy.sol";
+import {TokenizedStrategyLib as TokenizedStrategy} from "../../libraries/TokenizedStrategyLib.sol";
 
 contract MockStrategy is BaseStrategy {
     address public yieldSource;


### PR DESCRIPTION
Refactors strategy-side TokenizedStrategy access into a library alias. Simple view helpers read tokenized strategy storage directly, while more complex views still call back through the strategy fallback path.